### PR TITLE
Replace nbsp to spaces in json templates

### DIFF
--- a/parameters/reference/label-recognition-parameter/binarization-modes.md
+++ b/parameters/reference/label-recognition-parameter/binarization-modes.md
@@ -135,13 +135,13 @@ Sets the parameters passed to the library to load dynamically.
 **Json Parameter Example**   
 ```json
 {
-    "BinarizationModes": [
-        {
-            "Mode": "DLR_BM_LOCAL_BLOCK",
-            "BlockSizeX": 5,
-            "BlockSizeY": 5,
-        }
-    ]
+    "BinarizationModes": [
+        {
+            "Mode": "DLR_BM_LOCAL_BLOCK",
+            "BlockSizeX": 5,
+            "BlockSizeY": 5,
+        }
+    ]
 }
 ```
 

--- a/parameters/reference/label-recognition-parameter/grayscale-transformation-modes.md
+++ b/parameters/reference/label-recognition-parameter/grayscale-transformation-modes.md
@@ -75,14 +75,14 @@ Sets the parameters passed to the library to load dynamically.
 **Json Parameter Example**   
 ```json
 {
-    "GrayscaleTransformationModes": [
-        {
-            "Mode": "DLR_GTM_INVERTED"
-        },
+    "GrayscaleTransformationModes": [
+        {
+            "Mode": "DLR_GTM_INVERTED"
+        },
         {
             "Mode": "DLR_GTM_ORIGINAL"
         }
-    ]
+    ]
 }
 ```
 

--- a/parameters/reference/label-recognition-parameter/region-predetection-modes.md
+++ b/parameters/reference/label-recognition-parameter/region-predetection-modes.md
@@ -188,13 +188,13 @@ Sets the parameters passed to the library to load dynamically.
 **Json Parameter Example**   
 ```json
 {
-    "RegionPredetectionModes": [
-        {
-            "Mode": "DLR_RPM_GENERAL_GRAY_CONTRAST",
-            "Sensitivity": 5,
-            "MinImageDimension":262144
-        }
-    ]
+    "RegionPredetectionModes": [
+        {
+            "Mode": "DLR_RPM_GENERAL_GRAY_CONTRAST",
+            "Sensitivity": 5,
+            "MinImageDimension":262144
+        }
+    ]
 }
 ```
 

--- a/programming/c-cplusplus/user-guide.md
+++ b/programming/c-cplusplus/user-guide.md
@@ -116,17 +116,17 @@ To reference multiple regions, we cannot follow the runtime settings example abo
     string ReferenceRegionArray = 
     "\"ReferenceRegionArray\":[{\
         \"Localization\": \
-            {\
-                \"SourceType\": \"DLR_LST_PREDETECTED_REGION\",\
-                \"RegionPredetectionModesIndex\": 1\
-            },\
+            {\
+                \"SourceType\": \"DLR_LST_PREDETECTED_REGION\",\
+                \"RegionPredetectionModesIndex\": 1\
+            },\
         \"Name\":\"R1\"\
     },{\
         \"Localization\": \
-            {\
-                \"SourceType\": \"DLR_LST_PREDETECTED_REGION\",\
-                \"RegionPredetectionModesIndex\": 0\
-            },\
+            {\
+                \"SourceType\": \"DLR_LST_PREDETECTED_REGION\",\
+                \"RegionPredetectionModesIndex\": 0\
+            },\
         \"Name\":\"R2\"\
     }]";
     string DLRParameterArray = 
@@ -158,10 +158,10 @@ To reference multiple regions, we cannot follow the runtime settings example abo
     string ReferenceRegionArray = 
     "\"ReferenceRegionArray\":[{\
         \"Localization\": \
-            {\
-                \"SourceType\": \"DLR_LST_PREDETECTED_REGION\",\
-                \"RegionPredetectionModesIndex\": 1\
-            },\
+            {\
+                \"SourceType\": \"DLR_LST_PREDETECTED_REGION\",\
+                \"RegionPredetectionModesIndex\": 1\
+            },\
         \"Name\":\"R1\",\
         \"TextAreaNameArray\" : [ \"t1\", \"t2\" ]\
     }]";
@@ -248,10 +248,10 @@ Let's take a look at the following JSON settings file, `DLRTemplate.json`.
         {
             "Name":"R1",
             "Localization": 
-                {
-                    "SourceType": "DLR_LST_PREDETECTED_REGION",
-                    "RegionPredetectionModesIndex": 0
-                },
+                {
+                    "SourceType": "DLR_LST_PREDETECTED_REGION",
+                    "RegionPredetectionModesIndex": 0
+                },
             "TextAreaNameArray":["T1"]
         }
         ],


### PR DESCRIPTION
To avoid errors in rendered html.